### PR TITLE
Boycott

### DIFF
--- a/integrationTest/picket.spec.js
+++ b/integrationTest/picket.spec.js
@@ -22,15 +22,16 @@ const runTest = (name) => {
       await driver.sleep(1000)
       const text = await driver.findElement(By.id('warning-banner')).getText()
 
-      expect(text).to.contain('This website does not comply')
+      expect(text).to.contain('so so')
     })
 
     it('blocks', async () => {
       await driver.get('http://www.notarealwebsite.com')
       await driver.sleep(1000)
-      const text = await driver.findElement(By.css('.blocked-title')).getText()
+      const text = await driver.findElement(By.css('.content')).getText()
 
-      expect(text).to.contain('This site was blocked')
+      expect(text).to.contain('This site was blocked by pineapple')
+      expect(text).to.contain('not okay')
     })
   })
 }

--- a/src/backgroundScript/applyRules.js
+++ b/src/backgroundScript/applyRules.js
@@ -7,14 +7,26 @@ const shouldBlock = (blocked) => {
   return true
 }
 
-const blockRequest = (union, union_url, msg) => {
+const fetchBlockPage = (union, unionUrl, message) => {
   const unionEncoded = encodeURIComponent(union);
-  const unionUrlEncoded = encodeURIComponent(union_url);
-  const msgEncoded = encodeURIComponent(msg);
-  const extension = chrome
+  const unionUrlEncoded = encodeURIComponent(unionUrl);
+  const msgEncoded = encodeURIComponent(message);
+  return chrome
     .runtime
     .getURL(`blocked.html?union=${unionEncoded}&msg=${msgEncoded}&union_url=${unionUrlEncoded}`)
-  return { redirectUrl: extension }
+}
+
+const sendBoycottRequest = (url, message) => {
+  fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json'},
+    body: JSON.stringify({ message })
+  })
+}
+
+const blockRequest = (url, union, unionUrl, message) => {
+  sendBoycottRequest(url, message)
+  return { redirectUrl: fetchBlockPage(union, unionUrl, message) }
 }
 
 const prepareBanner = (url, msg) => {
@@ -37,7 +49,7 @@ export default (policy) => ({ url }) => {
 
   const blockAction = rule.actions.find(a => a.action === 'block')
   if (shouldBlock(blockAction)) {
-    return blockRequest(policy.name, policy.url, blockAction.message)
+    return blockRequest(url, policy.name, policy.url, blockAction.message)
   }
 
   const warn = rule.actions.find(a => a.action === 'warn')

--- a/src/backgroundScript/applyRules.spec.js
+++ b/src/backgroundScript/applyRules.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { stub } from 'sinon'
 import applyRules from './applyRules.js'
 
 global.chrome = { runtime: { getURL: (str) => str } }
@@ -8,91 +9,117 @@ const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toDateStr
 const dayBefore = new Date(new Date().getTime() - 48 * 60 * 60 * 1000).toDateString()
 
 describe('applyRules', () => {
-  it('cancels blocked url with no dates', () => {
-    const policy = {
-      "name": "pineapple",
-      "url": "www.pineapple.com",
-      "rules": [{
-        "sites": ["*://www.notarealwebsite.com/*"],
-        "actions": [{ "action": "block", "message": "not okay" }]
-      }]
-    }
-    const blockingResponse = applyRules(policy)({ url: 'http://www.notarealwebsite.com' })
-    const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
-    expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
-  })
+  afterEach(() => { global.fetch = stub() })
 
-  it('cancels blocked url with start date but no end date', () => {
-    const policy = {
-      "name": "pineapple",
-      "url": "www.pineapple.com",
-      "rules": [{
-        "sites": ["*://www.today.com/*"],
-        "actions": [{
-          "action": "block",
-          "message": "not okay",
-          "startDate": today
+  context('blocking', () => {
+    it('cancels blocked url with no dates', () => {
+      const policy = {
+        "name": "pineapple",
+        "url": "www.pineapple.com",
+        "rules": [{
+          "sites": ["*://www.notarealwebsite.com/*"],
+          "actions": [{ "action": "block", "message": "not okay" }]
         }]
-      }]
-    }
+      }
+      const blockingResponse = applyRules(policy)({ url: 'http://www.notarealwebsite.com' })
+      const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
+      expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
+    })
 
-    const blockingResponse = applyRules(policy)({ url: 'http://www.today.com' })
-    const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
-    expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
-  })
-
-  it('cancels blocked url with start and end date', () => {
-    const policy = {
-      "name": "pineapple",
-      "url": "www.pineapple.com",
-      "rules": [{
-        "sites": ["*://www.today.com/*"],
-        "actions": [{
-          "action": "block",
-          "message": "not okay",
-          "startDate": today,
-          "endDate": tomorrow
+    it('cancels blocked url with start date but no end date', () => {
+      const policy = {
+        "name": "pineapple",
+        "url": "www.pineapple.com",
+        "rules": [{
+          "sites": ["*://www.today.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay",
+            "startDate": today
+          }]
         }]
-      }]
-    }
-    const blockingResponse = applyRules(policy)({ url: 'http://www.today.com' })
-    const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
-    expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
-  })
+      }
 
-  it('does nothing if blocking start date is in the future', () => {
-    const policy = {
-      "name": "pineapple",
-      "rules": [{
-        "sites": ["*://www.tomorrow.com/*"],
-        "actions": [{
-          "action": "block",
-          "message": "not okay",
-          "startDate": tomorrow
-        }]
-      }]
-    }
-    const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
-    const expected = "blocked.html?union=pineapple&msg=not%20okay"
-    expect(blockingResponse).to.deep.equal({})
-  })
+      const blockingResponse = applyRules(policy)({ url: 'http://www.today.com' })
+      const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
+      expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
+    })
 
-  it('does nothing if blocking end date is passed', () => {
-    const policy = {
-      "name": "pineapple",
-      "rules": [{
-        "sites": ["*://www.yesterday.com/*"],
-        "actions": [{
-          "action": "block",
-          "message": "not okay",
-          "startDate": dayBefore,
-          "endDate": yesterday
+    it('cancels blocked url with start and end date', () => {
+      const policy = {
+        "name": "pineapple",
+        "url": "www.pineapple.com",
+        "rules": [{
+          "sites": ["*://www.today.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay",
+            "startDate": today,
+            "endDate": tomorrow
+          }]
         }]
-      }]
-    }
-    const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
-    const expected = "blocked.html?union=pineapple&msg=not%20okay"
-    expect(blockingResponse).to.deep.equal({})
+      }
+      const blockingResponse = applyRules(policy)({ url: 'http://www.today.com' })
+      const expected = "blocked.html?union=pineapple&msg=not%20okay&union_url=www.pineapple.com"
+      expect(blockingResponse).to.deep.equal({ redirectUrl: expected })
+    })
+
+    it('does nothing if blocking start date is in the future', () => {
+      const policy = {
+        "name": "pineapple",
+        "rules": [{
+          "sites": ["*://www.tomorrow.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay",
+            "startDate": tomorrow
+          }]
+        }]
+      }
+      const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
+      const expected = "blocked.html?union=pineapple&msg=not%20okay"
+      expect(blockingResponse).to.deep.equal({})
+    })
+
+    it('does nothing if blocking end date is passed', () => {
+      const policy = {
+        "name": "pineapple",
+        "rules": [{
+          "sites": ["*://www.yesterday.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay",
+            "startDate": dayBefore,
+            "endDate": yesterday
+          }]
+        }]
+      }
+      const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
+      const expected = "blocked.html?union=pineapple&msg=not%20okay"
+      expect(blockingResponse).to.deep.equal({})
+    })
+
+    it('sends boycott request when blocked page', () => {
+      const policy = {
+        "name": "pineapple",
+        "rules": [{
+          "sites": ["*://www.boycott.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay",
+          }]
+        }]
+      }
+      const blockingResponse = applyRules(policy)({ url: 'http://www.boycott.com' })
+      const expectedRequest = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json'},
+        body: '{"message":"not okay"}'
+      }
+
+      expect(global.fetch).to.have.been
+        .calledWith('http://www.boycott.com', expectedRequest)
+    })
   })
 
   it('does nothing if url not listed', () => {

--- a/src/backgroundScript/applyRules.spec.js
+++ b/src/backgroundScript/applyRules.spec.js
@@ -83,7 +83,6 @@ describe('applyRules', () => {
         }]
       }
       const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
-      const expected = "blocked.html?union=pineapple&msg=not%20okay"
       expect(blockingResponse).to.deep.equal({})
     })
 
@@ -101,7 +100,42 @@ describe('applyRules', () => {
         }]
       }
       const blockingResponse = applyRules(policy)({ url: 'http://www.tomorrow.com' })
-      const expected = "blocked.html?union=pineapple&msg=not%20okay"
+      expect(blockingResponse).to.deep.equal({})
+    })
+
+    it('does nothing if request stems from the firefox plugin itself', () => {
+      const policy = {
+        "name": "pineapple",
+        "rules": [{
+          "sites": ["*://www.someurl.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay"
+          }]
+        }]
+      }
+      const blockingResponse = applyRules(policy)({
+        url: 'http://www.someurl.com',
+        originUrl: 'moz-extension://ef1552b8-052b-cc40-96c4-9e5c96a04ab5'
+      })
+      expect(blockingResponse).to.deep.equal({})
+    })
+
+    it('does nothing if request stems from the chrome plugin itself', () => {
+      const policy = {
+        "name": "pineapple",
+        "rules": [{
+          "sites": ["*://www.someurl.com/*"],
+          "actions": [{
+            "action": "block",
+            "message": "not okay"
+          }]
+        }]
+      }
+      const blockingResponse = applyRules(policy)({
+        url: 'http://www.someurl.com',
+        initiator: 'chrome-extension://gobjlgheeckeagjkcpgeihdldilajlni'
+      })
       expect(blockingResponse).to.deep.equal({})
     })
 
@@ -116,7 +150,7 @@ describe('applyRules', () => {
           }]
         }]
       }
-      const blockingResponse = applyRules(policy)({ url: 'http://www.boycott.com' })
+      const blockingResponse = applyRules(policy)({ url: 'http://www.boycott.com/somePath' })
       const expectedRequest = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json'},
@@ -124,7 +158,7 @@ describe('applyRules', () => {
       }
 
       expect(global.fetch).to.have.been
-        .calledWith('http://www.boycott.com', expectedRequest)
+        .calledWith('http://www.boycott.com/boycott', expectedRequest)
     })
   })
 

--- a/src/blockedPage/blocked.js
+++ b/src/blockedPage/blocked.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const message = params.get("msg");
   const union = params.get("union");
   const union_url = params.get("union_url");
-  Array.forEach(document.querySelectorAll(".union-name"), (el,i) => { el.innerText = union; });
+  Array.from(document.querySelectorAll(".union-name"), (el,i) => { el.innerText = union; });
   document.getElementById("union-link").href = union_url;
   document.getElementById("loaded-message").innerText = message;
 });


### PR DESCRIPTION
Implements #3 with one of the listed approached. The suggested approach here is that we send the boycott request every time the user access a page that has been blocked.